### PR TITLE
Update CI documentation

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -13,7 +13,7 @@ Github:
 Gitlab:
 
 1. Login using team user
-2. https://gitlab.com/mysteriumnetwork → `New Project` → `CI/CD for external repo` → `Connect repositories from: Github`
+2. https://gitlab.com/mysteriumnetwork → `New Project → CI/CD for external repo → Connect repositories from: Github`
 3. Find the project in `From GitHub` column. 
 4. **IMPORTANT!** In `To GitLab` column, select `Groups/mysteriumnetwork`.
 ![Import Github project](../assets/img/ci/import-github-project.png)
@@ -22,3 +22,8 @@ Gitlab:
 That's all.  
 If everything went well, Gitlab will mirror updates whenever you push to any branch in Github repo.   
 If the project has `.gitlab-ci.yml`, Gitlab will run build pipeline and report build status back to the Github.
+
+## Post mirror setup
+
+1. We use group runners in Gitlab, under `mysteriumnetwork` group: https://gitlab.com/groups/mysteriumnetwork/-/settings/ci_cd
+To utilize them, disable Shared runners (that are enabled by default for new projects) in your project → `Settings → CI / CD → Runners`

--- a/ci/README.md
+++ b/ci/README.md
@@ -8,7 +8,7 @@ Pipeline build statuses are reported back to Github.
 
 Github:
 
-1. **IMPORTANT!** Add our team user as a collaborator (write access) to the project (to be able to create webhooks automatically)
+1. **IMPORTANT!** Add our team user as a collaborator (*admin* permission level) to the project (for Gitlab to create webhooks automatically). After initial setup is done, you may demote the permission level to *write*.
 
 Gitlab:
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,11 +4,20 @@ We use pipeline based [Gitlab CI/CD for Github](https://about.gitlab.com/solutio
 It creates a read-only mirror which is updated upon a push event from Github's webhook.
 Pipeline build statuses are reported back to Github.
 
+## Runner types
+
+Gitlab assigns jobs to runners (workers) based on tags and their availability. We have 2 types of runners (with corresponding tags). To assign your job to the runner, use the relevant tag.
+
+- `go`: a shell runner with go and some related tools pre-installed. Useful when you use docker for integration testing, so you cannot use docker runner. Example of usage: [node/go](https://github.com/mysteriumnetwork/node/blob/master/.gitlab-ci.yml)
+- `docker`: a general purpose docker runner which when provided with a needed docker image can be used for anything, from go to web projects. Example of usage: [feedback/go](https://github.com/mysteriumnetwork/feedback/blob/master/.gitlab-ci.yml) [terms/go+js](https://github.com/mysteriumnetwork/terms/blob/master/.gitlab-ci.yml)
+
+**Rule of the thumb**: if you don't use docker CLI in CI, then use `docker` runner.
+
 ## How to setup a Gitlab mirror for CI
 
 Github:
 
-1. **IMPORTANT!** Add our team user as a collaborator (*admin* permission level) to the project (for Gitlab to create webhooks automatically). After initial setup is done, you may demote the permission level to *write*.
+1. **IMPORTANT!** Add our team user as a collaborator (**admin** permission level) to the project (for Gitlab to create webhooks automatically). After initial setup is done, you may demote permission level to **write**.
 
 Gitlab:
 
@@ -25,5 +34,5 @@ If the project has `.gitlab-ci.yml`, Gitlab will run build pipeline and report b
 
 ## Post mirror setup
 
-1. We use group runners in Gitlab, under `mysteriumnetwork` group: https://gitlab.com/groups/mysteriumnetwork/-/settings/ci_cd
+- We use group runners in Gitlab, under [mysteriumnetwork group](https://gitlab.com/groups/mysteriumnetwork/-/settings/ci_cd).  
 To utilize them, disable Shared runners (that are enabled by default for new projects) in your project → `Settings → CI / CD → Runners`


### PR DESCRIPTION
* Github permission levels have been changed, so now Gitlab mirroring requires `admin` permissions for the initial setup
* Also describe runner types