### PR TITLE
Propose case for JSON fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ However, if exceptions occur frequently, consider adjusting guidelines (by creat
 - [Continuous integration](ci)
 - [Code review](code-review)
 - [Git](git)
+- [API](api)
 
 ## Contributing to devbook
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,5 @@
+# API
+
+## JSON format
+
+JSON fields should be snake_case.


### PR DESCRIPTION
There's no convention over field naming - it's all mixed.
I propose to use snake_case (for new APIs, and eventually, existing ones)
![Screenshot 2020-03-23 at 12 00 25](https://user-images.githubusercontent.com/4745368/77305032-03d4eb80-6cfe-11ea-8fbb-a97cf8e2b71a.png)
